### PR TITLE
Add Contact foreign key to Messaging model

### DIFF
--- a/helpline/admin.py
+++ b/helpline/admin.py
@@ -32,10 +32,6 @@ class ServiceAdmin(admin.ModelAdmin):
     list_display = ('name', 'extension', 'queue')
     exclude = ('id')
 
-class ServiceAdmin(admin.ModelAdmin):
-    list_display = ('name', 'extension', 'queue')
-    exclude = ('id')
-
 
 class HotdeskAdmin(admin.ModelAdmin):
     """Admin list for Hotdesk model"""

--- a/helpline/admin.py
+++ b/helpline/admin.py
@@ -12,28 +12,42 @@ class userInLine(admin.StackedInline):
     can_delete = False
     verbose_name_plural = 'Helpline Users'
 
+
 class UserAdmin(BaseUserAdmin):
     inlines = (userInLine,)
+
 
 class ParterAdmin(admin.ModelAdmin):
     list_display = ('id', 'referralpartner')
     exclude = ('tempid', 'counselling', 'shelter', 'afterschool',
                'soupkitchen', 'otherservicesinfo')
 
+
 class DialectAdmin(admin.ModelAdmin):
     list_display = ('id', 'hl_dialect')
     exclude = ('id', 'hl_category', 'hl_status')
 
+
 class ServiceAdmin(admin.ModelAdmin):
     list_display = ('name', 'extension', 'queue')
     exclude = ('id')
+
+class ServiceAdmin(admin.ModelAdmin):
+    list_display = ('name', 'extension', 'queue')
+    exclude = ('id')
+
+
+class HotdeskAdmin(admin.ModelAdmin):
+    """Admin list for Hotdesk model"""
+    list_display = ('extension', 'extension_type', 'status', 'agent')
+
 
 admin.site.unregister(User)
 admin.site.register(User, UserAdmin)
 admin.site.register(Schedule)
 admin.site.register(HelplineUser)
 admin.site.register(Service, ServiceAdmin)
-admin.site.register(Hotdesk)
+admin.site.register(Hotdesk, HotdeskAdmin)
 admin.site.register(Report)
 admin.site.register(Clock)
 admin.site.register(Category)

--- a/helpline/admin.py
+++ b/helpline/admin.py
@@ -24,12 +24,15 @@ class DialectAdmin(admin.ModelAdmin):
     list_display = ('id', 'hl_dialect')
     exclude = ('id', 'hl_category', 'hl_status')
 
+class ServiceAdmin(admin.ModelAdmin):
+    list_display = ('name', 'extension', 'queue')
+    exclude = ('id')
 
 admin.site.unregister(User)
 admin.site.register(User, UserAdmin)
 admin.site.register(Schedule)
 admin.site.register(HelplineUser)
-admin.site.register(Service)
+admin.site.register(Service, ServiceAdmin)
 admin.site.register(Hotdesk)
 admin.site.register(Report)
 admin.site.register(Clock)

--- a/helpline/models.py
+++ b/helpline/models.py
@@ -224,21 +224,6 @@ class MenuLog(models.Model):
     hl_time = models.IntegerField()
 
 
-class Messaging(models.Model):
-    hl_service = models.CharField(max_length=100, verbose_name='Service')
-    hl_contact = models.CharField(max_length=25, verbose_name='Contact')
-    hl_key = models.IntegerField(verbose_name='Key')
-    hl_type = models.CharField(max_length=6, verbose_name='Type')
-    hl_status = models.CharField(max_length=7, verbose_name='Status')
-    hl_staff = models.IntegerField(verbose_name='Staff', blank=True, null=True)
-    hl_content = models.TextField(verbose_name='Content')
-    hl_time = models.IntegerField(verbose_name='Time')
-
-    def get_formatted_time(self):
-        return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.hl_time))
-
-    def __unicode__(self):
-        return str(self.hl_contact)
 
 class Offered(models.Model):
     hl_case = models.IntegerField(unique=True)
@@ -507,6 +492,25 @@ class Report(models.Model):
 
         return reverse('my_forms', args=[self.casetype.lower() if self.casetype else "call"]) + "?case=%s" % str(self.case.hl_case)
 
+
+class Messaging(models.Model):
+    """Inbuilt messaging model"""
+    contact = models.ForeignKey(Contact, on_delete=models.CASCADE)
+    hl_service = models.CharField(max_length=100, verbose_name='Service')
+    hl_contact = models.CharField(max_length=25, verbose_name='Contact')
+    hl_key = models.IntegerField(verbose_name='Key')
+    hl_type = models.CharField(max_length=6, verbose_name='Type')
+    hl_status = models.CharField(max_length=7, verbose_name='Status')
+    hl_staff = models.IntegerField(verbose_name='Staff', blank=True, null=True)
+    hl_content = models.TextField(verbose_name='Content')
+    hl_time = models.IntegerField(verbose_name='Time')
+
+    def get_formatted_time(self):
+        """Get ISO formated time from time stamp"""
+        return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.hl_time))
+
+    def __unicode__(self):
+        return str(self.hl_contact)
 
 class Role(models.Model):
     hl_role = models.CharField(max_length=100)


### PR DESCRIPTION
We will be deprecating the use of Integer hl_"Keys" to identify objects in favor of Foreign Keys.
Refactored admin.py adding ServiceAdmin and HotdeskAdmin list displays.

Messaging app will be updated and replaced by RapidPro. Previous version was borrowed heavily from RapidSMS.


helpline/models.py
```
  498     contact = models.ForeignKey(
  499         Contact,
  500         on_delete=models.CASCADE,
  501         blank=True, null=True
  502     )
```

Means that we should highly discourage deletion of contacts as this will cascade to related messages.